### PR TITLE
Adjust overlay networks to avoid clash with boot2docker

### DIFF
--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -58,3 +58,7 @@ secrets:
     external: true
 networks:
   private:
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.31.0/24

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,4 +1,8 @@
-FROM golang:1.8
+FROM golang:1.8.1-alpine
+
+RUN apk add --update tini curl \
+  && rm -r /var/cache
+ENTRYPOINT ["/sbin/tini", "--"]
 
 RUN mkdir -p /go/src/app
 WORKDIR /go/src/app
@@ -11,4 +15,5 @@ EXPOSE 8080
 HEALTHCHECK --interval=5s --timeout=3s \
   CMD curl --fail http://localhost:8080/health || exit 1
 
+# Run under Tini
 CMD ["go-wrapper", "run", "main.go"]

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,8 +1,4 @@
-FROM golang:1.8.1-alpine
-
-RUN apk add --update tini curl \
-  && rm -r /var/cache
-ENTRYPOINT ["/sbin/tini", "--"]
+FROM golang:1.8
 
 RUN mkdir -p /go/src/app
 WORKDIR /go/src/app
@@ -15,5 +11,4 @@ EXPOSE 8080
 HEALTHCHECK --interval=5s --timeout=3s \
   CMD curl --fail http://localhost:8080/health || exit 1
 
-# Run under Tini
 CMD ["go-wrapper", "run", "main.go"]

--- a/readme.md
+++ b/readme.md
@@ -128,3 +128,11 @@ docker-machine rm -f mgr1 wkr1 wkr2 wkr3
     docker stop load-balancer
     docker rm load-balancer
     ```
+
+A note about overlay networks
+-----
+
+Be careful of clashes between `Boot2Docker`'s networking and `docker swarm`'s overlay networks
+(they both use `10.0.n/24`). This is why we change the subnet for the `private` overlay network in
+[the compose file](./docker-compose-app.yml) (as we ended up looking for a DNS server on the
+`private` network rather than on the host)


### PR DESCRIPTION
We were having problems doing dns lookups in alpine linux from go. Nslookup also couldn't resolve (although dig and node progs could).
See https://github.com/moby/moby/issues/29398
So we switched to ubuntu base image.
No need to merge this unless you also need to do dns resolution inside the container.