### PR TITLE
split scripts for registry and load-balancer

### DIFF
--- a/provisioning/osx/docker-compose-load-balancer.yml
+++ b/provisioning/osx/docker-compose-load-balancer.yml
@@ -1,16 +1,12 @@
 version: "3.1"
 
 services:
-  registry:
-    image: registry:2
-    ports:
-      - 5000:5000
-    volumes:
-      - /tmp/registry:/var/lib/registry
   load_balancer:
     image: nginx
     ports:
       - 80:80
+    networks:
+      - load_balancer
     extra_hosts:
       - "mgr1:${mgr1}"
       - "wkr1:${wkr1}"
@@ -18,3 +14,5 @@ services:
       - "wkr3:${wkr3}"
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
+networks:
+  load_balancer:

--- a/provisioning/osx/docker-compose-registry.yml
+++ b/provisioning/osx/docker-compose-registry.yml
@@ -1,0 +1,13 @@
+version: "3.1"
+
+services:
+  registry:
+    image: registry:2
+    ports:
+      - 5000:5000
+    networks:
+      - registry
+    volumes:
+      - /tmp/registry:/var/lib/registry
+networks:
+  registry:

--- a/provisioning/osx/load-balancer.sh
+++ b/provisioning/osx/load-balancer.sh
@@ -4,8 +4,6 @@ scriptDir=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd )
 
 cd "$scriptDir"
 
-mkdir -p /tmp/registry
-
 source point-to-local.sh
 
 for node in mgr1 wkr1 wkr2 wkr3
@@ -13,4 +11,4 @@ do
   eval "export ${node}=$(docker-machine ip $node)"
 done
 
-docker-compose -f docker-compose-local.yml up -d
+docker-compose -f docker-compose-load-balancer.yml -p load-balancer up -d

--- a/provisioning/osx/local-cleanup.sh
+++ b/provisioning/osx/local-cleanup.sh
@@ -8,4 +8,5 @@ cd "$scriptDir"
 
 source point-to-local.sh
 
-docker-compose -f docker-compose-local.yml down
+docker-compose -f docker-compose-load-balancer.yml down
+docker-compose -f docker-compose-registry.yml down

--- a/provisioning/osx/registry.sh
+++ b/provisioning/osx/registry.sh
@@ -6,4 +6,6 @@ cd "$scriptDir"
 
 source point-to-local.sh
 
+mkdir -p /tmp/registry
+
 docker-compose -f docker-compose-registry.yml -p registry up -d

--- a/provisioning/osx/registry.sh
+++ b/provisioning/osx/registry.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+scriptDir=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd )
+
+cd "$scriptDir"
+
+source point-to-local.sh
+
+docker-compose -f docker-compose-registry.yml -p registry up -d

--- a/readme.md
+++ b/readme.md
@@ -18,10 +18,10 @@ Incoming requests can hit any node of the swarm and will be routed to an instanc
     sh provisioning/osx/swarm.sh
     ```
 
-1.  There's also a script to create a local private registry and a load balancer (both outside the swarm). Note that if the IP addresses of your VMs change, you'll need to run this script again, so that the load balancer points to the correct nodes.
+1.  There's also a script to create a local private registry.
 
     ```sh
-    sh provisioning/osx/local.sh
+    sh provisioning/osx/registry.sh
     ```
 
 1. In order to push images to the local private registry, you will need to create an alias to `localhost` for `registry` in `/etc/hosts`:
@@ -54,18 +54,24 @@ Incoming requests can hit any node of the swarm and will be routed to an instanc
     sh deploy.sh
     ```
 
-    You should now see all the services running
+1.  There's a script to create a load balancer (also outside the swarm). Note that if the IP addresses of your VMs change, you'll need to run this script again, so that the load balancer points to the correct nodes.
 
     ```sh
-    docker service ls
-    ID            NAME                 MODE        REPLICAS  IMAGE
-    16aozwerflj8  app_web              replicated  3/3       registry:5000/web:latest
-    8nyovw1xqnwh  app_rproxy           replicated  3/3       registry:5000/app_rproxy:latest
-    d0p2a0toiizi  app_api              replicated  3/3       registry:5000/api:latest
-    ivea53e00djo  services_rproxy      replicated  1/1       registry:5000/services_rproxy:latest
-    n1m32eri5qay  services_visualizer  replicated  1/1       charypar/swarm-dashboard:latest
-    v6ex7zwvvbng  app_gateway          replicated  3/3       registry:5000/proxy:latest
+    sh provisioning/osx/load-balancer.sh
     ```
+
+You should now see all the services running:
+
+```sh
+docker service ls
+ID            NAME                 MODE        REPLICAS  IMAGE
+16aozwerflj8  app_web              replicated  3/3       registry:5000/web:latest
+8nyovw1xqnwh  app_rproxy           replicated  3/3       registry:5000/app_rproxy:latest
+d0p2a0toiizi  app_api              replicated  3/3       registry:5000/api:latest
+ivea53e00djo  services_rproxy      replicated  1/1       registry:5000/services_rproxy:latest
+n1m32eri5qay  services_visualizer  replicated  1/1       charypar/swarm-dashboard:latest
+v6ex7zwvvbng  app_gateway          replicated  3/3       registry:5000/proxy:latest
+```
 
 ## Cleaning up
 


### PR DESCRIPTION
Registry has to be created before swarm services can be deployed, but nginx won't start if the services aren't there. So we split the compose files so that we could manage them separately (registry created before and nginx after).