### PR TITLE
Add local mirror for Docker hub

### DIFF
--- a/provisioning/osx/docker-compose-registry.yml
+++ b/provisioning/osx/docker-compose-registry.yml
@@ -2,12 +2,24 @@ version: "3.1"
 
 services:
   registry:
+    restart: always
     image: registry:2
     ports:
       - 5000:5000
+    volumes:
+      - ${HOME}/.docker/registry:/var/lib/registry
     networks:
       - registry
+  registry-mirror:
+    restart: always
+    image: registry:2
+    ports:
+      - 5001:5000
+    environment:
+      REGISTRY_PROXY_REMOTEURL: https://registry-1.docker.io
     volumes:
-      - /tmp/registry:/var/lib/registry
+      - ${HOME}/.docker/registry-mirror:/var/lib/registry
+    networks:
+      - registry
 networks:
   registry:

--- a/provisioning/osx/local-cleanup.sh
+++ b/provisioning/osx/local-cleanup.sh
@@ -13,5 +13,5 @@ cd "$scriptDir"
 
 compose="./on-local.sh docker-compose"
 
-$compose -f docker-compose-load-balancer.yml down
-$compose -f docker-compose-registry.yml down
+$compose -f docker-compose-load-balancer.yml -p load-balancer down
+$compose -f docker-compose-registry.yml -p registry down

--- a/provisioning/osx/registry.sh
+++ b/provisioning/osx/registry.sh
@@ -12,7 +12,8 @@ cd "$scriptDir"
 compose="./on-local.sh docker-compose"
 docker="./on-swarm.sh docker"
 
-mkdir -p /tmp/registry
+mkdir -p $HOME/.docker/registry
+mkdir -p $HOME/.docker/registry-mirror
 
 $compose -f docker-compose-registry.yml -p registry up -d
 $docker stack deploy -c docker-compose-registry-ambassador.yml swarm

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 This repo is a noddy web ui and proxied api (on a private network) with `version 3` compose files that are designed to be deployed into a "Docker in swarm mode" cluster.
 
 There are 5 compose files:
-  1. private Docker registry (external to the swarm).
+  1. private Docker registry and registry mirror (external to the swarm).
   1. `nginx` load balancer (external to the swarm).
   1. the swarm visualizer, and its reverse proxy (`services` stack)
   1. the registry ambassador (`swarm` stack)
@@ -16,13 +16,18 @@ Incoming requests can hit any node of the swarm and will be routed to an instanc
 ## To set up the cluster
 1.  Install VirtualBox and Docker for Mac (I had a few problems deploying a stack with 17.06 so maybe use 17.05 or below).
 
-1.  There's a script to create a swarm, which provisions 4 local VMs and joins them into a cluster. Take a look at the script to see how straight forward it is.
+1.  Run the script to create a swarm, which provisions 4 local VMs and joins them into a cluster. Take a look at the script to see how straight forward it is.
 
     ```bash
     ./provisioning/osx/swarm.sh
     ```
 
-1.  There's also a script to create a local private registry.
+1.  Run the script to create a load balancer (also outside the swarm). Note that if the IP addresses of your VMs change, you'll need to run this script again, so that the load balancer points to the correct nodes.
+
+    ```sh
+    ./provisioning/osx/load-balancer.sh
+    ```
+1.  Run the script to create a local private Docker registry and a local mirror of Docker hub.
 
     ```sh
     ./provisioning/osx/registry.sh
@@ -53,12 +58,6 @@ Incoming requests can hit any node of the swarm and will be routed to an instanc
 
     ```sh
     ./deploy-app.sh
-    ```
-
-1.  There's a script to create a load balancer (also outside the swarm). Note that if the IP addresses of your VMs change, you'll need to run this script again, so that the load balancer points to the correct nodes.
-
-    ```sh
-    ./provisioning/osx/load-balancer.sh
     ```
 
     The app should now be available at http://localhost and the visualizer at http://localhost/_cluster/swarm/


### PR DESCRIPTION
If/when you re-create your swarm, having a local mirror of Docker hub helps massively.

Currently it has to be a new instance of `registry:2` because pushing to a registry that is acting as a mirror is not supported