### PR TITLE
move proxy config file to /tmp

### DIFF
--- a/provisioning/osx/configure/src/haproxy.js
+++ b/provisioning/osx/configure/src/haproxy.js
@@ -50,7 +50,7 @@ backend ${name}.${s.stack}.${domain}
   )}`;
 
 export const write = contents => {
-  const file = '/tmp/haproxy/haproxy.cfg';
+  const file = '/tmp/haproxy.cfg';
   console.log(`Writing ${file}`); // eslint-disable-line
   fs.writeFileSync(file, contents);
 };

--- a/provisioning/osx/configure/src/haproxy.spec.js
+++ b/provisioning/osx/configure/src/haproxy.spec.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { create } from './haproxy';
 
 describe('haproxy', () => {
-  it('should write the correct config', () => {
+  it('should create the correct config', () => {
     const services = [
       {
         stack: 'services',

--- a/provisioning/osx/docker-compose-load-balancer.yml
+++ b/provisioning/osx/docker-compose-load-balancer.yml
@@ -13,6 +13,6 @@ services:
       - "wkr2:${wkr2}"
       - "wkr3:${wkr3}"
     volumes:
-      - /tmp/haproxy:/usr/local/etc/haproxy
+      - /tmp/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
 networks:
   load_balancer:


### PR DESCRIPTION
Would fail if the directory `/tmp/haproxy` didn't exist, so moved to `/tmp` instead