### PR TITLE
Substitute tag in compose-file with git sha

### DIFF
--- a/.buildkite/steps/build.sh
+++ b/.buildkite/steps/build.sh
@@ -4,6 +4,7 @@ set -eux
 
 env
 export registry=localhost:5000
+export tag=latest
 
 cd example
 

--- a/configure/package.json
+++ b/configure/package.json
@@ -16,6 +16,7 @@
     "dockerode": "^2.5.1",
     "execa": "^0.8.0",
     "get-stream": "^3.0.0",
+    "git-repo-info": "^1.4.1",
     "js-yaml": "^3.10.0",
     "mkdirp": "^0.5.1",
     "ramda": "^0.24.1",

--- a/configure/src/compose-file.js
+++ b/configure/src/compose-file.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import getRepoInfo from 'git-repo-info';
 import getStream from 'get-stream';
 import path from 'path';
 import { chain, forEach, fromPairs, groupBy, join, map, toPairs } from 'ramda';
@@ -26,6 +27,7 @@ ${join('', map(genService, services))}
 
 export const mergeFn = async (cmd, args) => {
   const env = await getEnv('local');
+  env.tag = process.env.tag || getRepoInfo().abbreviatedSha;
   const cp = exec(env, cmd, args, false, true);
   return getStream(cp.stdout);
 };

--- a/configure/yarn.lock
+++ b/configure/yarn.lock
@@ -1652,6 +1652,10 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+git-repo-info@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/git-repo-info/-/git-repo-info-1.4.1.tgz#2a072823254aaf62fcf0766007d7b6651bd41943"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"

--- a/example/app.yml
+++ b/example/app.yml
@@ -2,7 +2,7 @@ version: "3.1"
 
 services:
   rproxy:
-    image: ${registry}/rproxy
+    image: ${registry}/rproxy:${tag}
     build: rproxy
     environment:
       PORT: 3000
@@ -21,7 +21,7 @@ services:
         constraints:
           - node.role == worker
   web:
-    image: ${registry}/web
+    image: ${registry}/web:${tag}
     build: web
     environment:
       PORT: 3000
@@ -39,7 +39,7 @@ services:
         constraints:
           - node.role == worker
   gateway:
-    image: ${registry}/gateway
+    image: ${registry}/gateway:${tag}
     build: gateway
     environment:
       PORT: 3000
@@ -58,7 +58,7 @@ services:
         constraints:
           - node.role == worker
   api:
-    image: ${registry}/api
+    image: ${registry}/api:${tag}
     build: api
     environment:
       PORT: 3000


### PR DESCRIPTION
This PR enables substitution of `${tag}` in our `compose-file` with the current git `sha` (if an environment variable of the same name is not set).

We should obtain the abbreviated `sha` by ascending directories until a `.git` directory is found.